### PR TITLE
Fix join form terms checkbox detection

### DIFF
--- a/public/js/join.js
+++ b/public/js/join.js
@@ -5,6 +5,7 @@ const errorEls = new Map(
     el,
   ])
 );
+const termsCheckbox = form.querySelector("input[name='terms']");
 
 function showError(field, message) {
   const errorEl = errorEls.get(field);
@@ -52,7 +53,7 @@ form.addEventListener("submit", (event) => {
 
   const name = form.elements.name.value.trim();
   const email = form.elements.email.value.trim();
-  const termsAccepted = form.elements.terms.checked;
+  const termsAccepted = termsCheckbox ? termsCheckbox.checked : false;
 
   let hasError = false;
 


### PR DESCRIPTION
## Summary
- ensure the join form reads the terms checkbox element directly
- allow the checkbox state to be honored so valid submissions redirect to the painter page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e52c10359c833099512e2357401d16