### PR TITLE
Ensure join form always redirects to painter page

### DIFF
--- a/public/join.html
+++ b/public/join.html
@@ -10,7 +10,7 @@
     <main class="join-card">
       <h1>Join the Graffiti Wall</h1>
       <p>Fill in your details to jump into the shared canvas.</p>
-      <form id="join-form" class="join-form" novalidate>
+      <form id="join-form" class="join-form" action="/paint" method="get">
         <div class="field">
           <label for="name">Name</label>
           <input id="name" name="name" type="text" maxlength="60" required placeholder="Your name" />


### PR DESCRIPTION
## Summary
- make the join form default to /paint so it works even without JavaScript
- guard the enhanced validation script and use normal form submission on success to ensure navigation
- keep local storage identity restore while falling back gracefully when the form is missing

## Testing
- npm install *(fails: registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e52e9ddc788330ab8eb8882139f443