### PR TITLE
Fix handling for /public-prefixed URLs

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,12 +29,28 @@ const SOCKET_IO_CLIENT_BUNDLE = path.join(
 
 const PORT = process.env.PORT || 3000;
 const MAX_STROKES = 15000;
+const PUBLIC_PATH_PREFIX = /^\/(?:public\/)+/i;
 
 /**
  * In-memory store of spray events.
  * Each stroke: { x: number, y: number, radius: number, color: string }
  */
 const strokes = [];
+
+app.use((req, res, next) => {
+  if (req.path === "/public") {
+    const query = req.originalUrl.slice(req.path.length);
+    return res.redirect(301, `/${query}`);
+  }
+
+  if (PUBLIC_PATH_PREFIX.test(req.path)) {
+    const normalizedPath = req.path.replace(PUBLIC_PATH_PREFIX, "/");
+    const query = req.originalUrl.slice(req.path.length);
+    return res.redirect(301, `${normalizedPath}${query}`);
+  }
+
+  next();
+});
 
 app.use(express.static(PUBLIC_DIR));
 app.use("/js", express.static(PUBLIC_JS_DIR));


### PR DESCRIPTION
## Summary
- normalize requests that include repeated `/public` prefixes so they redirect to the intended route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5653feae48330a6cc073e42015a34